### PR TITLE
Bayesian algorithm's state clearing fix and an example addition.

### DIFF
--- a/CPDShell/Core/algorithms/BayesianCPD/localizers/simple_localizer.py
+++ b/CPDShell/Core/algorithms/BayesianCPD/localizers/simple_localizer.py
@@ -26,4 +26,4 @@ class SimpleLocalizer(ILocalizer):
         if len(growth_probs) == 0:
             return 0
 
-        return int(np.argmax(growth_probs[0 : len(growth_probs) - 1]))
+        return int(growth_probs[0 : len(growth_probs) - 1].argmax())

--- a/CPDShell/Core/algorithms/bayesian_algorithm.py
+++ b/CPDShell/Core/algorithms/bayesian_algorithm.py
@@ -81,11 +81,11 @@ class BayesianAlgorithm(Algorithm):
         """
         sample = list(window)
         sample_size = len(sample)
-        assert sample_size > 0
+        # assert sample_size > 0
+        if sample_size == 0:
+            return
 
-        self.__growth_probs = np.zeros(sample_size)
-        self.__growth_probs[0] = 1.0
-        self.__time = 0
+        self.__prepare(sample_size)
 
         while self.__time + self._learning_steps < sample_size:
             self.__learning_stage(sample)
@@ -204,6 +204,19 @@ class BayesianAlgorithm(Algorithm):
         :param shift: a time shift to add to the current time.
         """
         self.__time += shift
+
+    def __prepare(self, sample_size: int) -> None:
+        """
+        Clear algorithm's state (including change points and time related information) before data processing.
+        :param sample_size: an overall size of the sample.
+        """
+        self.__time = 0
+        self.__gap_size = 0
+
+        self.__change_points = []
+        self.__change_points_count = 0
+
+        self.__clear(sample_size)
 
     def __clear(self, sample_size: int) -> None:
         """

--- a/CPDShell/Core/algorithms/bayesian_algorithm.py
+++ b/CPDShell/Core/algorithms/bayesian_algorithm.py
@@ -81,7 +81,6 @@ class BayesianAlgorithm(Algorithm):
         """
         sample = list(window)
         sample_size = len(sample)
-        # assert sample_size > 0
         if sample_size == 0:
             return
 

--- a/CPDShell/Core/scrubber/scrubber.py
+++ b/CPDShell/Core/scrubber/scrubber.py
@@ -16,7 +16,7 @@ class Scrubber:
         scenario: Scenario,
         data,
         window_length: int = 10,
-        movement_k: float = 1 / 3,
+        movement_k: float = 1.0 / 3.0,
     ) -> None:
         """A scrubber for dividing data into windows
         and subsequent processing of data windows
@@ -29,7 +29,7 @@ class Scrubber:
         """
 
         self.window_length = window_length
-        self._movement_k = movement_k
+        self.movement_k = movement_k
         self.scenario = scenario
         self.data: Sequence[float | numpy.float64] = data
         self.is_running = True
@@ -68,7 +68,7 @@ class Scrubber:
             start, end = self.change_points[-1], self.change_points[-1] + self.window_length
             self._next_window = (start, end)
         else:
-            delta = int(self._movement_k * self.window_length)
+            delta = int(self.movement_k * self.window_length)
             start, end = self._next_window[0] + delta, self._next_window[1] + delta
             if end >= len(self.data):
                 self._next_window = None

--- a/CPDShell/main.py
+++ b/CPDShell/main.py
@@ -1,4 +1,5 @@
 import tempfile
+import time
 from pathlib import Path
 
 from CPDShell.Core.algorithms.bayesian_algorithm import BayesianAlgorithm
@@ -59,3 +60,8 @@ with tempfile.TemporaryDirectory() as tempdir_graph:
     res_bayes.visualize(True)
     print("Bayesian algorithm")
     print(res_bayes)
+
+    start_without_shell = time.perf_counter()
+    print("Result without a shell:", bayesian_algorithm.localize(data))
+    end_without_shell = time.perf_counter()
+    print("Time in seconds without a shell:", end_without_shell - start_without_shell)

--- a/CPDShell/main.py
+++ b/CPDShell/main.py
@@ -1,5 +1,3 @@
-import tempfile
-import time
 from pathlib import Path
 
 from CPDShell.Core.algorithms.bayesian_algorithm import BayesianAlgorithm
@@ -12,56 +10,50 @@ from CPDShell.generator.generator import ScipyDatasetGenerator
 from CPDShell.generator.saver import DatasetSaver
 from CPDShell.shell import CPDShell
 
-with tempfile.TemporaryDirectory() as tempdir_graph:
-    path_string = "tests/test_CPDShell/test_configs/test_config_exp.yml"
-    distributions_name = "exp"
+path_string = "tests/test_CPDShell/test_configs/test_config_exp.yml"
+distributions_name = "exp"
 
-    saver = DatasetSaver(Path(), True)
-    generated = ScipyDatasetGenerator().generate_datasets(Path(path_string), saver)
-    data, actual_change_points = generated[distributions_name]
+saver = DatasetSaver(Path(), True)
+generated = ScipyDatasetGenerator().generate_datasets(Path(path_string), saver)
+data, actual_change_points = generated[distributions_name]
 
-    graph_cpd = CPDShell(data)
-    graph_cpd.scrubber.window_length = 150
-    graph_cpd.scrubber.movement_k = 2.0 / 3.0
+graph_cpd = CPDShell(data)
+graph_cpd.scrubber.window_length = 150
+graph_cpd.scrubber.movement_k = 2.0 / 3.0
 
-    print("Actual change points:", actual_change_points)
+print("Actual change points:", actual_change_points)
 
-    res_graph = graph_cpd.run_cpd()
-    res_graph.visualize(True)
-    print("Graph algorithm")
-    print(res_graph)
+res_graph = graph_cpd.run_cpd()
+res_graph.visualize(True)
+print("Graph algorithm")
+print(res_graph)
 
-    HAZARD_RATE = 200
-    LEARNING_WINDOW_SIZE = 30
-    THRESHOLD = 0.5
-    DROP_THRESHOLD = 0.7
+HAZARD_RATE = 200
+LEARNING_WINDOW_SIZE = 30
+THRESHOLD = 0.5
+DROP_THRESHOLD = 0.7
 
-    constant_hazard = ConstantHazard(HAZARD_RATE)
-    gaussian_likelihood = GaussianLikelihood()
+constant_hazard = ConstantHazard(HAZARD_RATE)
+gaussian_likelihood = GaussianLikelihood()
 
-    simple_detector = SimpleDetector(THRESHOLD)
-    drop_detector = DropDetector(DROP_THRESHOLD)
+simple_detector = SimpleDetector(THRESHOLD)
+drop_detector = DropDetector(DROP_THRESHOLD)
 
-    simple_localizer = SimpleLocalizer()
+simple_localizer = SimpleLocalizer()
 
-    bayesian_algorithm = BayesianAlgorithm(
-        learning_steps=LEARNING_WINDOW_SIZE,
-        likelihood=gaussian_likelihood,
-        hazard=constant_hazard,
-        detector=drop_detector,
-        localizer=simple_localizer,
-    )
+bayesian_algorithm = BayesianAlgorithm(
+    learning_steps=LEARNING_WINDOW_SIZE,
+    likelihood=gaussian_likelihood,
+    hazard=constant_hazard,
+    detector=drop_detector,
+    localizer=simple_localizer,
+)
 
-    bayesian_cpd = CPDShell(data)
-    bayesian_cpd.scrubber.window_length = 200
-    bayesian_cpd.scrubber.movement_k = 2.0 / 3.0
+bayesian_cpd = CPDShell(data, bayesian_algorithm)
+bayesian_cpd.scrubber.window_length = 500
+bayesian_cpd.scrubber.movement_k = 2.0 / 3.0
 
-    res_bayes = bayesian_cpd.run_cpd()
-    res_bayes.visualize(True)
-    print("Bayesian algorithm")
-    print(res_bayes)
-
-    start_without_shell = time.perf_counter()
-    print("Result without a shell:", bayesian_algorithm.localize(data))
-    end_without_shell = time.perf_counter()
-    print("Time in seconds without a shell:", end_without_shell - start_without_shell)
+res_bayes = bayesian_cpd.run_cpd()
+res_bayes.visualize(True)
+print("Bayesian algorithm")
+print(res_bayes)

--- a/CPDShell/main.py
+++ b/CPDShell/main.py
@@ -1,17 +1,60 @@
 import tempfile
 from pathlib import Path
 
+from CPDShell.Core.algorithms.bayesian_algorithm import BayesianAlgorithm
+from CPDShell.Core.algorithms.BayesianCPD.detectors.drop_detector import DropDetector
+from CPDShell.Core.algorithms.BayesianCPD.detectors.simple_detector import SimpleDetector
+from CPDShell.Core.algorithms.BayesianCPD.hazards.constant_hazard import ConstantHazard
+from CPDShell.Core.algorithms.BayesianCPD.likelihoods.gaussian_likelihood import GaussianLikelihood
+from CPDShell.Core.algorithms.BayesianCPD.localizers.simple_localizer import SimpleLocalizer
 from CPDShell.generator.generator import ScipyDatasetGenerator
 from CPDShell.generator.saver import DatasetSaver
 from CPDShell.shell import CPDShell
 
-with tempfile.TemporaryDirectory() as tempdir:
+with tempfile.TemporaryDirectory() as tempdir_graph:
+    path_string = "tests/test_CPDShell/test_configs/test_config_exp.yml"
+    distributions_name = "exp"
+
     saver = DatasetSaver(Path(), True)
-    generated = ScipyDatasetGenerator().generate_datasets(
-        Path("tests/test_CPDShell/test_configs/test_config_exp.yml"), saver
+    generated = ScipyDatasetGenerator().generate_datasets(Path(path_string), saver)
+
+    graph_cpd = CPDShell(generated[distributions_name][0])
+    graph_cpd.scrubber.window_length = 200
+    graph_cpd.scrubber.movement_k = 2.0 / 3.0
+
+    res = graph_cpd.run_cpd()
+    res.visualize(True)
+    print("Graph algorithm")
+    print(res)
+
+    HAZARD_RATE = 200
+    LEARNING_WINDOW_SIZE = 30
+    THRESHOLD = 0.5
+    DROP_THRESHOLD = 0.7
+
+    saver = DatasetSaver(Path(), True)
+    generated = ScipyDatasetGenerator().generate_datasets(Path(path_string), saver)
+
+    constant_hazard = ConstantHazard(HAZARD_RATE)
+    gaussian_likelihood = GaussianLikelihood()
+
+    simple_detector = SimpleDetector(THRESHOLD)
+    drop_detector = DropDetector(DROP_THRESHOLD)
+
+    simple_localizer = SimpleLocalizer()
+    bayesian_algorithm = BayesianAlgorithm(
+        learning_steps=LEARNING_WINDOW_SIZE,
+        likelihood=gaussian_likelihood,
+        hazard=constant_hazard,
+        detector=drop_detector,
+        localizer=simple_localizer,
     )
 
-    cpd = CPDShell(generated["exp"][0])
-    res = cpd.run_cpd()
+    bayesian_cpd = CPDShell(generated[distributions_name][0])
+    bayesian_cpd.scrubber.window_length = 200
+    bayesian_cpd.scrubber.movement_k = 2.0 / 3.0
+
+    res = bayesian_cpd.run_cpd()
     res.visualize(True)
+    print("Bayesian algorithm")
     print(res)

--- a/CPDShell/main.py
+++ b/CPDShell/main.py
@@ -15,13 +15,13 @@ distributions_name = "exp"
 
 saver = DatasetSaver(Path(), True)
 generated = ScipyDatasetGenerator().generate_datasets(Path(path_string), saver)
-data, actual_change_points = generated[distributions_name]
+data, expected_change_points = generated[distributions_name]
 
 graph_cpd = CPDShell(data)
 graph_cpd.scrubber.window_length = 150
 graph_cpd.scrubber.movement_k = 2.0 / 3.0
 
-print("Actual change points:", actual_change_points)
+print("Expected change points:", expected_change_points)
 
 res_graph = graph_cpd.run_cpd()
 res_graph.visualize(True)

--- a/CPDShell/main.py
+++ b/CPDShell/main.py
@@ -17,23 +17,23 @@ with tempfile.TemporaryDirectory() as tempdir_graph:
 
     saver = DatasetSaver(Path(), True)
     generated = ScipyDatasetGenerator().generate_datasets(Path(path_string), saver)
+    data, actual_change_points = generated[distributions_name]
 
-    graph_cpd = CPDShell(generated[distributions_name][0])
-    graph_cpd.scrubber.window_length = 200
+    graph_cpd = CPDShell(data)
+    graph_cpd.scrubber.window_length = 150
     graph_cpd.scrubber.movement_k = 2.0 / 3.0
 
-    res = graph_cpd.run_cpd()
-    res.visualize(True)
+    print("Actual change points:", actual_change_points)
+
+    res_graph = graph_cpd.run_cpd()
+    res_graph.visualize(True)
     print("Graph algorithm")
-    print(res)
+    print(res_graph)
 
     HAZARD_RATE = 200
     LEARNING_WINDOW_SIZE = 30
     THRESHOLD = 0.5
     DROP_THRESHOLD = 0.7
-
-    saver = DatasetSaver(Path(), True)
-    generated = ScipyDatasetGenerator().generate_datasets(Path(path_string), saver)
 
     constant_hazard = ConstantHazard(HAZARD_RATE)
     gaussian_likelihood = GaussianLikelihood()
@@ -42,6 +42,7 @@ with tempfile.TemporaryDirectory() as tempdir_graph:
     drop_detector = DropDetector(DROP_THRESHOLD)
 
     simple_localizer = SimpleLocalizer()
+
     bayesian_algorithm = BayesianAlgorithm(
         learning_steps=LEARNING_WINDOW_SIZE,
         likelihood=gaussian_likelihood,
@@ -50,11 +51,11 @@ with tempfile.TemporaryDirectory() as tempdir_graph:
         localizer=simple_localizer,
     )
 
-    bayesian_cpd = CPDShell(generated[distributions_name][0])
+    bayesian_cpd = CPDShell(data)
     bayesian_cpd.scrubber.window_length = 200
     bayesian_cpd.scrubber.movement_k = 2.0 / 3.0
 
-    res = bayesian_cpd.run_cpd()
-    res.visualize(True)
+    res_bayes = bayesian_cpd.run_cpd()
+    res_bayes.visualize(True)
     print("Bayesian algorithm")
-    print(res)
+    print(res_bayes)

--- a/CPDShell/shell.py
+++ b/CPDShell/shell.py
@@ -21,18 +21,18 @@ class CPContainer:
         data: Sequence[float | numpy.float64],
         result: list[int],
         expected_result: list[int] | None,
-        time_ms: float,
+        time_sec: float,
     ) -> None:
         """Object constructor
 
         :param: result: list, containing change points, that were found by CPD algos
         :param: expected_result: list, containing expected change points, if it is needed
-        :param: time_ms: a float number, time of CPD algo execution in milliseconds
+        :param: time_sec: a float number, time of CPD algo execution in fractional seconds
         """
         self.data = data
         self.result = result
         self.expected_result = expected_result
-        self.time_ms = time_ms
+        self.time_sec = time_sec
 
     @property
     def result_diff(self) -> list:
@@ -57,7 +57,7 @@ class CPContainer:
             diff = ";".join(map(str, self.result_diff))
             method_output += f"Expected change point: ({expected_cp_results})\n"
             method_output += f"Difference: ({diff})\n"
-        method_output += f"Computation time (ms): {round(self.time_ms, 2)}"
+        method_output += f"Computation time (sec): {round(self.time_sec, 2)}"
         return method_output
 
     def visualize(self, to_show: bool = True, output_directory: Path | None = None, name: str = "Graph") -> None:

--- a/tests/test_CPDShell/test_shell.py
+++ b/tests/test_CPDShell/test_shell.py
@@ -110,7 +110,7 @@ class TestCPContainer:
             == """Located change points: (1;2;3)
 Expected change point: (2;3;4)
 Difference: (1;4)
-Computation time (ms): 10"""
+Computation time (sec): 10"""
         )
 
         assert (
@@ -118,13 +118,13 @@ Computation time (ms): 10"""
             == """Located change points: (1;2;3;6;8)
 Expected change point: (2;3;4;6)
 Difference: (1;4;8)
-Computation time (ms): 20"""
+Computation time (sec): 20"""
         )
 
         assert (
             str(self.cont_no_expected)
             == """Located change points: (1;2;3)
-Computation time (ms): 5"""
+Computation time (sec): 5"""
         )
 
     @pytest.mark.parametrize(


### PR DESCRIPTION
Bayesian algorithm's state was not cleared properly. It resulted in change points accumulation on different samples (when we're using a single instance of algorithm) and lack of clearing likelohood's parameters after the first sample.

I also added an example in `main.py` and restructured it for a better comparability. Scrubber advanced settings required making `movement_k` a public property.